### PR TITLE
Make GTK Docs optional

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-gtkdocize || exit 1
+which gtkdocize && ( gtkdocize || exit 1 )
 
 if test -n "$AUTOMAKE"; then
     : # don't override an explicit user request

--- a/configure.ac
+++ b/configure.ac
@@ -278,7 +278,13 @@ dnl To be used by tests and examples
 WOCKY_CFLAGS='-I${top_builddir} -I${top_srcdir}'
 AC_SUBST(WOCKY_CFLAGS)
 
+# check for gtk-doc
+m4_ifdef([GTK_DOC_CHECK], [
 GTK_DOC_CHECK([1.17],[--flavour no-tmpl])
+],[
+AM_CONDITIONAL([ENABLE_GTK_DOC], false)
+])
+
 
 AC_OUTPUT( Makefile            \
            wocky/Makefile      \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,1 +1,3 @@
+if ENABLE_GTK_DOC
 SUBDIRS = reference
+endif

--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -2,6 +2,7 @@
 
 # We require automake 1.6 at least.
 AUTOMAKE_OPTIONS = 1.6
+if ENABLE_GTK_DOC
 
 # This is a blank Makefile.am for using gtk-doc.
 # Copy this to your project's API docs directory and modify the variables to
@@ -101,3 +102,4 @@ DISTCLEANFILES = wocky-sections.txt wocky.types
 # Comment this out if you want your docs-status tested during 'make check'
 #TESTS = $(GTKDOC_CHECK)
 
+endif #ENABLE_GTK_DOC


### PR DESCRIPTION
GTK Docs is quite a big pile of dependencies with questional benefit for the (intermediate) package builds.
This patch makes GTK Docs optional and will use it only if it is present on the system (eg for release build)