### PR TITLE
Bump the glib api implementation to the latest version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,10 +120,7 @@ AC_C_BIGENDIAN
 
 dnl Check for Glib
 PKG_CHECK_MODULES(GLIB,
-  [glib-2.0 >= 2.44, gobject-2.0 >= 2.44, gthread-2.0 >= 2.44, gio-2.0 >= 2.44])
-
-AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_44], [Ignore post 2.44 deprecations])
-AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_44], [Prevent post 2.44 APIs])
+  [glib-2.0 >= 2.46, gobject-2.0 >= 2.46, gthread-2.0 >= 2.46, gio-2.0 >= 2.46])
 
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)

--- a/examples/dump-certificates.c
+++ b/examples/dump-certificates.c
@@ -59,7 +59,7 @@ dump_tls_handler_verify_async (WockyTLSHandler *self,
     GAsyncReadyCallback callback,
     gpointer user_data)
 {
-  GSimpleAsyncResult *res;
+  GTask *task;
   GPtrArray *chain;
   gnutls_x509_crt_t cert;
   gnutls_datum_t datum;
@@ -106,10 +106,9 @@ dump_tls_handler_verify_async (WockyTLSHandler *self,
 
   g_ptr_array_unref (chain);
 
-  res = g_simple_async_result_new (G_OBJECT (self), callback, user_data,
-      dump_tls_handler_verify_async);
-  g_simple_async_result_complete_in_idle (res);
-  g_object_unref (res);
+  task = g_task_new (G_OBJECT (self), NULL, callback, user_data);
+  g_task_return_boolean (task, TRUE);
+  g_object_unref (task);
 }
 
 static gboolean
@@ -117,8 +116,9 @@ dump_tls_handler_verify_finish (WockyTLSHandler *self,
     GAsyncResult *result,
     GError **error)
 {
-  return !g_simple_async_result_propagate_error (G_SIMPLE_ASYNC_RESULT (result),
-      error);
+  g_return_val_if_fail (g_task_is_valid (result, self), FALSE);
+
+  return g_task_propagate_boolean (G_TASK (result), error);
 }
 
 static void

--- a/tests/wocky-connector-test.c
+++ b/tests/wocky-connector-test.c
@@ -3385,8 +3385,19 @@ test_server_teardown_cb (GObject *source,
 static gboolean
 test_server_idle_quit_loop_cb (GMainLoop *loop)
 {
-    g_main_loop_quit (loop);
-    return G_SOURCE_REMOVE;
+  static int retries = 0;
+
+  if (retries == 5)
+    {
+      g_main_loop_quit (loop);
+      retries = 0;
+      return G_SOURCE_REMOVE;
+    }
+  else
+    {
+      retries ++;
+      return G_SOURCE_CONTINUE;
+    }
 }
 
 static void

--- a/tests/wocky-connector-test.c
+++ b/tests/wocky-connector-test.c
@@ -3419,6 +3419,7 @@ test_server_teardown (test_t *test,
       g_main_loop_run (loop);
 
       g_clear_object (&srv->server);
+      g_main_loop_unref (loop);
     }
 
   if (srv->watch != 0)

--- a/tests/wocky-pubsub-service-test.c
+++ b/tests/wocky-pubsub-service-test.c
@@ -643,6 +643,7 @@ test_create_node_config (void)
 
 /* Four examples taken from §5.6 Retrieve Subscriptions */
 typedef enum {
+    MODE_CAN_DO,
     MODE_NORMAL,
     MODE_NO_SUBSCRIPTIONS,
     MODE_BZZT,
@@ -734,6 +735,7 @@ test_retrieve_subscriptions_iq_cb (
 
   switch (ctx->mode)
     {
+    case MODE_CAN_DO:
     case MODE_NORMAL:
       reply = make_subscriptions_response (stanza, NULL, normal_subs);
       break;
@@ -790,6 +792,10 @@ retrieve_subscriptions_cb (GObject *source,
 
   switch (ctx->mode)
     {
+    case MODE_CAN_DO:
+      g_assert (wocky_pubsub_service_retrieve_subscriptions_finish (
+          WOCKY_PUBSUB_SERVICE (source), res, NULL, &error));
+      break;
     case MODE_NORMAL:
       check_subscriptions (source, res, normal_subs);
       break;
@@ -874,6 +880,9 @@ main (int argc, char **argv)
       "/pubsub-service/get-default-node-configuration-insufficient",
       test_get_default_node_configuration_insufficient);
 
+  g_test_add_data_func ("/pubsub-service/retrieve-subscriptions/can-do",
+      GUINT_TO_POINTER (MODE_CAN_DO),
+      test_retrieve_subscriptions);
   g_test_add_data_func ("/pubsub-service/retrieve-subscriptions/normal",
       GUINT_TO_POINTER (MODE_NORMAL),
       test_retrieve_subscriptions);

--- a/tests/wocky-test-connector-server.c
+++ b/tests/wocky-test-connector-server.c
@@ -1390,8 +1390,17 @@ force_closed_cb (GObject *source,
   success = wocky_xmpp_connection_force_close_finish (
     WOCKY_XMPP_CONNECTION (source),
     result, &error);
-  g_assert_no_error (error);
-  g_assert (success);
+  if (success)
+    {
+      g_assert_no_error (error);
+    }
+  else if (self->priv->teardown_task && self->priv->cancellable == NULL)
+    {
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
+      g_error_free (error);
+    }
+  else
+    g_assert_not_reached ();
 
   server_dec_outstanding (self);
 }

--- a/tests/wocky-test-connector-server.h
+++ b/tests/wocky-test-connector-server.h
@@ -190,7 +190,7 @@ void test_connector_server_teardown (TestConnectorServer *self,
 
 gboolean test_connector_server_teardown_finish (TestConnectorServer *self,
   GAsyncResult *result,
-  GError *error);
+  GError **error);
 
 const gchar *test_connector_server_get_used_mech (TestConnectorServer *self);
 

--- a/tests/wocky-xmpp-connection-test.c
+++ b/tests/wocky-xmpp-connection-test.c
@@ -740,12 +740,12 @@ test_error_is_open_or_closed (void)
     WOCKY_STANZA_SUB_TYPE_CHAT, "a"," b", NULL);
 
 
+  wocky_xmpp_connection_recv_open_async (WOCKY_XMPP_CONNECTION (test->out),
+    NULL, is_open_recv_open_cb, test);
+
   wocky_xmpp_connection_send_open_async (WOCKY_XMPP_CONNECTION (test->in),
     NULL, NULL, NULL, NULL, NULL,
     NULL, is_open_send_open_cb, test);
-
-  wocky_xmpp_connection_recv_open_async (WOCKY_XMPP_CONNECTION (test->out),
-    NULL, is_open_recv_open_cb, test);
 
   test->outstanding = 2;
   test_wait_pending (test);

--- a/wocky/wocky-bare-contact.c
+++ b/wocky/wocky-bare-contact.c
@@ -50,8 +50,6 @@
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_ROSTER
 #include "wocky-debug-internal.h"
 
-G_DEFINE_TYPE (WockyBareContact, wocky_bare_contact, WOCKY_TYPE_CONTACT)
-
 /* properties */
 enum
 {
@@ -87,12 +85,13 @@ struct _WockyBareContactPrivate
   GSList *resources;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyBareContact, wocky_bare_contact,
+                WOCKY_TYPE_CONTACT, G_ADD_PRIVATE(WockyBareContact))
+
 static void
 wocky_bare_contact_init (WockyBareContact *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
-      WOCKY_TYPE_BARE_CONTACT, WockyBareContactPrivate);
-
+  self->priv = wocky_bare_contact_get_instance_private (self);
   self->priv->resources = NULL;
 }
 
@@ -227,9 +226,6 @@ wocky_bare_contact_class_init (WockyBareContactClass *wocky_bare_contact_class)
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_bare_contact_class);
   WockyContactClass *contact_class = WOCKY_CONTACT_CLASS (wocky_bare_contact_class);
   GParamSpec *spec;
-
-  g_type_class_add_private (wocky_bare_contact_class,
-      sizeof (WockyBareContactPrivate));
 
   object_class->constructed = wocky_bare_contact_constructed;
   object_class->set_property = wocky_bare_contact_set_property;

--- a/wocky/wocky-caps-cache.c
+++ b/wocky/wocky-caps-cache.c
@@ -40,8 +40,6 @@
 
 #define DB_USER_VERSION 2
 
-G_DEFINE_TYPE (WockyCapsCache, wocky_caps_cache, G_TYPE_OBJECT)
-
 static WockyCapsCache *shared_cache = NULL;
 
 struct _WockyCapsCachePrivate
@@ -53,6 +51,9 @@ struct _WockyCapsCachePrivate
   WockyXmppReader *reader;
   WockyXmppWriter *writer;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyCapsCache, wocky_caps_cache, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyCapsCache))
 
 enum
 {
@@ -139,8 +140,6 @@ static void
 wocky_caps_cache_class_init (WockyCapsCacheClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (WockyCapsCachePrivate));
 
   object_class->constructed = wocky_caps_cache_constructed;
   object_class->get_property = wocky_caps_cache_get_property;
@@ -359,8 +358,7 @@ wocky_caps_cache_constructed (GObject *object)
 static void
 wocky_caps_cache_init (WockyCapsCache *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (
-      self, WOCKY_TYPE_CAPS_CACHE, WockyCapsCachePrivate);
+  self->priv = wocky_caps_cache_get_instance_private (self);
 }
 
 /**

--- a/wocky/wocky-contact-factory.c
+++ b/wocky/wocky-contact-factory.c
@@ -51,8 +51,6 @@
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_ROSTER
 #include "wocky-debug-internal.h"
 
-G_DEFINE_TYPE (WockyContactFactory, wocky_contact_factory, G_TYPE_OBJECT)
-
 #if 0
 /* properties */
 enum
@@ -84,13 +82,15 @@ struct _WockyContactFactoryPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyContactFactory, wocky_contact_factory,
+                        G_TYPE_OBJECT, G_ADD_PRIVATE (WockyContactFactory))
+
 static void
 wocky_contact_factory_init (WockyContactFactory *self)
 {
   WockyContactFactoryPrivate *priv;
 
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_CONTACT_FACTORY,
-      WockyContactFactoryPrivate);
+  self->priv = wocky_contact_factory_get_instance_private (self);
   priv = self->priv;
 
   priv->bare_contacts = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
@@ -210,9 +210,6 @@ wocky_contact_factory_class_init (
     WockyContactFactoryClass *wocky_contact_factory_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_contact_factory_class);
-
-  g_type_class_add_private (wocky_contact_factory_class,
-      sizeof (WockyContactFactoryPrivate));
 
   object_class->constructed = wocky_contact_factory_constructed;
   object_class->set_property = wocky_contact_factory_set_property;

--- a/wocky/wocky-contact.c
+++ b/wocky/wocky-contact.c
@@ -48,8 +48,6 @@
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_ROSTER
 #include "wocky-debug-internal.h"
 
-G_DEFINE_TYPE (WockyContact, wocky_contact, G_TYPE_OBJECT)
-
 /* signal enum */
 enum
 {
@@ -66,11 +64,13 @@ struct _WockyContactPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyContact, wocky_contact, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyContact))
+
 static void
 wocky_contact_init (WockyContact *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_CONTACT,
-    WockyContactPrivate);
+  self->priv = wocky_contact_get_instance_private (self);
 }
 
 static void
@@ -146,9 +146,6 @@ static void
 wocky_contact_class_init (WockyContactClass *wocky_contact_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_contact_class);
-
-  g_type_class_add_private (wocky_contact_class,
-      sizeof (WockyContactPrivate));
 
   object_class->constructed = wocky_contact_constructed;
   object_class->set_property = wocky_contact_set_property;

--- a/wocky/wocky-data-form.c
+++ b/wocky/wocky-data-form.c
@@ -42,8 +42,6 @@
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_DATA_FORM
 #include "wocky-debug-internal.h"
 
-G_DEFINE_TYPE (WockyDataForm, wocky_data_form, G_TYPE_OBJECT)
-
 /* properties */
 enum
 {
@@ -62,6 +60,9 @@ struct _WockyDataFormPrivate
 
   gboolean dispose_has_run;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyDataForm, wocky_data_form, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyDataForm))
 
 GQuark
 wocky_data_form_error_quark (void)
@@ -150,8 +151,7 @@ wocky_data_form_field_free (WockyDataFormField *field)
 static void
 wocky_data_form_init (WockyDataForm *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_DATA_FORM,
-      WockyDataFormPrivate);
+  self->priv = wocky_data_form_get_instance_private (self);
 
   self->fields = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
   self->fields_list = NULL;
@@ -256,9 +256,6 @@ wocky_data_form_class_init (
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_data_form_class);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (wocky_data_form_class,
-      sizeof (WockyDataFormPrivate));
 
   object_class->set_property = wocky_data_form_set_property;
   object_class->get_property = wocky_data_form_get_property;

--- a/wocky/wocky-jabber-auth-digest.c
+++ b/wocky/wocky-jabber-auth-digest.c
@@ -11,9 +11,6 @@
 static void
 auth_handler_iface_init (gpointer g_iface);
 
-G_DEFINE_TYPE_WITH_CODE (WockyJabberAuthDigest, wocky_jabber_auth_digest, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
-
 enum
 {
   PROP_SESSION_ID = 1,
@@ -25,6 +22,10 @@ struct _WockyJabberAuthDigestPrivate
   gchar *session_id;
   gchar *password;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyJabberAuthDigest, wocky_jabber_auth_digest, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJabberAuthDigest)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
 
 static void
 wocky_jabber_auth_digest_get_property (GObject *object, guint property_id,
@@ -88,8 +89,6 @@ wocky_jabber_auth_digest_class_init (WockyJabberAuthDigestClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (WockyJabberAuthDigestPrivate));
-
   object_class->get_property = wocky_jabber_auth_digest_get_property;
   object_class->set_property = wocky_jabber_auth_digest_set_property;
   object_class->dispose = wocky_jabber_auth_digest_dispose;
@@ -123,8 +122,7 @@ auth_handler_iface_init (gpointer g_iface)
 static void
 wocky_jabber_auth_digest_init (WockyJabberAuthDigest *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (
-      self, WOCKY_TYPE_JABBER_AUTH_DIGEST, WockyJabberAuthDigestPrivate);
+  self->priv = wocky_jabber_auth_digest_get_instance_private (self);
 }
 
 WockyJabberAuthDigest *

--- a/wocky/wocky-jabber-auth-password.c
+++ b/wocky/wocky-jabber-auth-password.c
@@ -11,9 +11,6 @@
 static void
 auth_handler_iface_init (gpointer g_iface);
 
-G_DEFINE_TYPE_WITH_CODE (WockyJabberAuthPassword, wocky_jabber_auth_password, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
-
 enum
 {
   PROP_PASSWORD = 1
@@ -23,6 +20,10 @@ struct _WockyJabberAuthPasswordPrivate
 {
   gchar *password;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyJabberAuthPassword, wocky_jabber_auth_password, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJabberAuthPassword)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
 
 static void
 wocky_jabber_auth_password_get_property (GObject *object, guint property_id,
@@ -76,8 +77,6 @@ wocky_jabber_auth_password_class_init (WockyJabberAuthPasswordClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (WockyJabberAuthPasswordPrivate));
-
   object_class->get_property = wocky_jabber_auth_password_get_property;
   object_class->set_property = wocky_jabber_auth_password_set_property;
   object_class->dispose = wocky_jabber_auth_password_dispose;
@@ -106,8 +105,7 @@ auth_handler_iface_init (gpointer g_iface)
 static void
 wocky_jabber_auth_password_init (WockyJabberAuthPassword *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (
-      self, WOCKY_TYPE_JABBER_AUTH_PASSWORD, WockyJabberAuthPasswordPrivate);
+  self->priv = wocky_jabber_auth_password_get_instance_private (self);
 }
 
 WockyJabberAuthPassword *

--- a/wocky/wocky-jingle-content.c
+++ b/wocky/wocky-jingle-content.c
@@ -94,7 +94,8 @@ struct _WockyJingleContentPrivate
 
 /* lookup tables */
 
-G_DEFINE_TYPE(WockyJingleContent, wocky_jingle_content, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_CODE (WockyJingleContent, wocky_jingle_content, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJingleContent));
 
 static void new_transport_candidates_cb (WockyJingleTransportIface *trans,
     GList *candidates, WockyJingleContent *content);
@@ -105,8 +106,7 @@ static void
 wocky_jingle_content_init (WockyJingleContent *obj)
 {
   WockyJingleContentPrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_CONTENT,
-         WockyJingleContentPrivate);
+      wocky_jingle_content_get_instance_private (obj);
   obj->priv = priv;
 
   DEBUG ("%p", obj);
@@ -273,8 +273,6 @@ wocky_jingle_content_class_init (WockyJingleContentClass *cls)
 {
   GParamSpec *param_spec;
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
-
-  g_type_class_add_private (cls, sizeof (WockyJingleContentPrivate));
 
   object_class->get_property = wocky_jingle_content_get_property;
   object_class->set_property = wocky_jingle_content_set_property;

--- a/wocky/wocky-jingle-factory.c
+++ b/wocky/wocky-jingle-factory.c
@@ -40,8 +40,6 @@
 
 #include "wocky-google-relay.h"
 
-G_DEFINE_TYPE(WockyJingleFactory, wocky_jingle_factory, G_TYPE_OBJECT);
-
 /* signal enum */
 enum
 {
@@ -75,6 +73,9 @@ struct _WockyJingleFactoryPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyJingleFactory, wocky_jingle_factory, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJingleFactory));
+
 static gboolean jingle_cb (
     WockyPorter *porter,
     WockyStanza *msg,
@@ -102,8 +103,7 @@ static void
 wocky_jingle_factory_init (WockyJingleFactory *obj)
 {
   WockyJingleFactoryPrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_FACTORY,
-         WockyJingleFactoryPrivate);
+      wocky_jingle_factory_get_instance_private (obj);
   obj->priv = priv;
 
   priv->sessions = g_hash_table_new_full (g_str_hash, g_str_equal,
@@ -212,8 +212,6 @@ wocky_jingle_factory_class_init (WockyJingleFactoryClass *cls)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (cls, sizeof (WockyJingleFactoryPrivate));
 
   object_class->constructed = wocky_jingle_factory_constructed;
   object_class->get_property = wocky_jingle_factory_get_property;

--- a/wocky/wocky-jingle-info.c
+++ b/wocky/wocky-jingle-info.c
@@ -102,13 +102,13 @@ wocky_stun_server_free (WockyStunServer *stun_server)
     }
 }
 
-G_DEFINE_TYPE (WockyJingleInfo, wocky_jingle_info, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_CODE (WockyJingleInfo, wocky_jingle_info, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJingleInfo))
 
 static void
 wocky_jingle_info_init (WockyJingleInfo *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_JINGLE_INFO,
-      WockyJingleInfoPrivate);
+  self->priv = wocky_jingle_info_get_instance_private (self);
 
   self->priv->relay_http_port = 80;
   self->priv->get_stun_from_jingle = TRUE;
@@ -221,8 +221,6 @@ wocky_jingle_info_class_init (WockyJingleInfoClass *klass)
   object_class->set_property = wocky_jingle_info_set_property;
   object_class->constructed = wocky_jingle_info_constructed;
   object_class->dispose = wocky_jingle_info_dispose;
-
-  g_type_class_add_private (klass, sizeof (WockyJingleInfoPrivate));
 
   param_spec = g_param_spec_object ("porter", "WockyC2SPorter",
       "Porter for the current connection",

--- a/wocky/wocky-jingle-media-rtp.c
+++ b/wocky/wocky-jingle-media-rtp.c
@@ -40,9 +40,6 @@
 #include "wocky-jingle-transport-google.h"
 #include "wocky-utils.h"
 
-G_DEFINE_TYPE (WockyJingleMediaRtp,
-    wocky_jingle_media_rtp, WOCKY_TYPE_JINGLE_CONTENT);
-
 /* signal enum */
 enum
 {
@@ -85,12 +82,15 @@ struct _WockyJingleMediaRtpPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyJingleMediaRtp,
+    wocky_jingle_media_rtp, WOCKY_TYPE_JINGLE_CONTENT,
+          G_ADD_PRIVATE (WockyJingleMediaRtp));
+
 static void
 wocky_jingle_media_rtp_init (WockyJingleMediaRtp *obj)
 {
   WockyJingleMediaRtpPrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_MEDIA_RTP,
-         WockyJingleMediaRtpPrivate);
+      wocky_jingle_media_rtp_get_instance_private (obj);
   obj->priv = priv;
   priv->dispose_has_run = FALSE;
 }
@@ -313,8 +313,6 @@ wocky_jingle_media_rtp_class_init (WockyJingleMediaRtpClass *cls)
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
   WockyJingleContentClass *content_class = WOCKY_JINGLE_CONTENT_CLASS (cls);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (cls, sizeof (WockyJingleMediaRtpPrivate));
 
   object_class->get_property = wocky_jingle_media_rtp_get_property;
   object_class->set_property = wocky_jingle_media_rtp_set_property;

--- a/wocky/wocky-jingle-session.c
+++ b/wocky/wocky-jingle-session.c
@@ -41,8 +41,6 @@
 #include "wocky-resource-contact.h"
 #include "wocky-utils.h"
 
-G_DEFINE_TYPE(WockyJingleSession, wocky_jingle_session, G_TYPE_OBJECT);
-
 /* signal enum */
 enum
 {
@@ -106,6 +104,9 @@ struct _WockyJingleSessionPrivate
 
   gboolean dispose_has_run;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyJingleSession, wocky_jingle_session, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJingleSession));
 
 typedef struct {
   WockyJingleState state;
@@ -189,8 +190,7 @@ static void
 wocky_jingle_session_init (WockyJingleSession *obj)
 {
   WockyJingleSessionPrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_SESSION,
-         WockyJingleSessionPrivate);
+      wocky_jingle_session_get_instance_private (obj);
   obj->priv = priv;
 
   DEBUG ("Initializing the jingle session %p", obj);
@@ -413,8 +413,6 @@ wocky_jingle_session_class_init (WockyJingleSessionClass *cls)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (cls, sizeof (WockyJingleSessionPrivate));
 
   object_class->constructed = wocky_jingle_session_constructed;
   object_class->get_property = wocky_jingle_session_get_property;

--- a/wocky/wocky-jingle-transport-google.c
+++ b/wocky/wocky-jingle-transport-google.c
@@ -38,11 +38,6 @@
 static void
 transport_iface_init (gpointer g_iface, gpointer iface_data);
 
-G_DEFINE_TYPE_WITH_CODE (WockyJingleTransportGoogle,
-    wocky_jingle_transport_google, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_JINGLE_TRANSPORT_IFACE,
-        transport_iface_init));
-
 /* signal enum */
 enum
 {
@@ -82,12 +77,17 @@ struct _WockyJingleTransportGooglePrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyJingleTransportGoogle,
+    wocky_jingle_transport_google, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJingleTransportGoogle)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_JINGLE_TRANSPORT_IFACE,
+        transport_iface_init));
+
 static void
 wocky_jingle_transport_google_init (WockyJingleTransportGoogle *obj)
 {
   WockyJingleTransportGooglePrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_TRANSPORT_GOOGLE,
-         WockyJingleTransportGooglePrivate);
+      wocky_jingle_transport_google_get_instance_private (obj);
   obj->priv = priv;
 
   priv->component_names = g_hash_table_new_full (g_str_hash, g_str_equal,
@@ -180,8 +180,6 @@ wocky_jingle_transport_google_class_init (WockyJingleTransportGoogleClass *cls)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (cls, sizeof (WockyJingleTransportGooglePrivate));
 
   object_class->get_property = wocky_jingle_transport_google_get_property;
   object_class->set_property = wocky_jingle_transport_google_set_property;

--- a/wocky/wocky-jingle-transport-iceudp.c
+++ b/wocky/wocky-jingle-transport-iceudp.c
@@ -38,11 +38,6 @@
 static void
 transport_iface_init (gpointer g_iface, gpointer iface_data);
 
-G_DEFINE_TYPE_WITH_CODE (WockyJingleTransportIceUdp,
-    wocky_jingle_transport_iceudp, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_JINGLE_TRANSPORT_IFACE,
-        transport_iface_init));
-
 /* signal enum */
 enum
 {
@@ -85,12 +80,17 @@ struct _WockyJingleTransportIceUdpPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyJingleTransportIceUdp,
+    wocky_jingle_transport_iceudp, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyJingleTransportIceUdp)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_JINGLE_TRANSPORT_IFACE,
+        transport_iface_init));
+
 static void
 wocky_jingle_transport_iceudp_init (WockyJingleTransportIceUdp *obj)
 {
   WockyJingleTransportIceUdpPrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_TRANSPORT_ICEUDP,
-         WockyJingleTransportIceUdpPrivate);
+      wocky_jingle_transport_iceudp_get_instance_private (obj);
   obj->priv = priv;
 
   priv->id_sequence = 1;
@@ -184,8 +184,6 @@ wocky_jingle_transport_iceudp_class_init (WockyJingleTransportIceUdpClass *cls)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (cls, sizeof (WockyJingleTransportIceUdpPrivate));
 
   object_class->get_property = wocky_jingle_transport_iceudp_get_property;
   object_class->set_property = wocky_jingle_transport_iceudp_set_property;

--- a/wocky/wocky-jingle-transport-rawudp.c
+++ b/wocky/wocky-jingle-transport-rawudp.c
@@ -37,11 +37,6 @@
 static void
 transport_iface_init (gpointer g_iface, gpointer iface_data);
 
-G_DEFINE_TYPE_WITH_CODE (WockyJingleTransportRawUdp,
-    wocky_jingle_transport_rawudp, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_JINGLE_TRANSPORT_IFACE,
-        transport_iface_init));
-
 /* signal enum */
 enum
 {
@@ -71,12 +66,17 @@ struct _WockyJingleTransportRawUdpPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyJingleTransportRawUdp,
+    wocky_jingle_transport_rawudp, G_TYPE_OBJECT,
+        G_ADD_PRIVATE (WockyJingleTransportRawUdp)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_JINGLE_TRANSPORT_IFACE,
+        transport_iface_init));
+
 static void
 wocky_jingle_transport_rawudp_init (WockyJingleTransportRawUdp *obj)
 {
   WockyJingleTransportRawUdpPrivate *priv =
-     G_TYPE_INSTANCE_GET_PRIVATE (obj, WOCKY_TYPE_JINGLE_TRANSPORT_RAWUDP,
-         WockyJingleTransportRawUdpPrivate);
+      wocky_jingle_transport_rawudp_get_instance_private (obj);
   obj->priv = priv;
 
   priv->dispose_has_run = FALSE;
@@ -163,8 +163,6 @@ wocky_jingle_transport_rawudp_class_init (WockyJingleTransportRawUdpClass *cls)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (cls, sizeof (WockyJingleTransportRawUdpPrivate));
 
   object_class->get_property = wocky_jingle_transport_rawudp_get_property;
   object_class->set_property = wocky_jingle_transport_rawudp_set_property;

--- a/wocky/wocky-ll-contact.c
+++ b/wocky/wocky-ll-contact.c
@@ -35,8 +35,6 @@
 
 #include "wocky-utils.h"
 
-G_DEFINE_TYPE (WockyLLContact, wocky_ll_contact, WOCKY_TYPE_CONTACT)
-
 /* properties */
 enum
 {
@@ -57,11 +55,13 @@ struct _WockyLLContactPrivate
   gchar *jid;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyLLContact, wocky_ll_contact, WOCKY_TYPE_CONTACT,
+          G_ADD_PRIVATE (WockyLLContact))
+
 static void
 wocky_ll_contact_init (WockyLLContact *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
-      WOCKY_TYPE_LL_CONTACT, WockyLLContactPrivate);
+  self->priv = wocky_ll_contact_get_instance_private (self);
 }
 
 static void
@@ -136,9 +136,6 @@ wocky_ll_contact_class_init (WockyLLContactClass *wocky_ll_contact_class)
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_ll_contact_class);
   WockyContactClass *contact_class = WOCKY_CONTACT_CLASS (wocky_ll_contact_class);
   GParamSpec *spec;
-
-  g_type_class_add_private (wocky_ll_contact_class,
-      sizeof (WockyLLContactPrivate));
 
   object_class->constructed = wocky_ll_contact_constructed;
   object_class->set_property = wocky_ll_contact_set_property;

--- a/wocky/wocky-node-tree.c
+++ b/wocky/wocky-node-tree.c
@@ -29,8 +29,6 @@
 #include "wocky-node-tree.h"
 #include "wocky-node-private.h"
 
-G_DEFINE_TYPE(WockyNodeTree, wocky_node_tree, G_TYPE_OBJECT)
-
 /* properties */
 enum {
   PROP_TOP_NODE = 1,
@@ -42,11 +40,13 @@ struct _WockyNodeTreePrivate
   WockyNode *node;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyNodeTree, wocky_node_tree, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyNodeTree))
+
 static void
 wocky_node_tree_init (WockyNodeTree *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_NODE_TREE,
-      WockyNodeTreePrivate);
+  self->priv = wocky_node_tree_get_instance_private (self);
 }
 
 static void wocky_node_tree_dispose (GObject *object);
@@ -96,9 +96,6 @@ wocky_node_tree_class_init (WockyNodeTreeClass *wocky_node_tree_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_node_tree_class);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (wocky_node_tree_class,
-    sizeof (WockyNodeTreePrivate));
 
   object_class->dispose = wocky_node_tree_dispose;
   object_class->finalize = wocky_node_tree_finalize;

--- a/wocky/wocky-ping.c
+++ b/wocky/wocky-ping.c
@@ -39,8 +39,6 @@
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_PING
 #include "wocky-debug-internal.h"
 
-G_DEFINE_TYPE (WockyPing, wocky_ping, G_TYPE_OBJECT)
-
 /* properties */
 enum
 {
@@ -61,6 +59,9 @@ struct _WockyPingPrivate
   gboolean dispose_has_run;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyPing, wocky_ping, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyPing))
+
 static void send_ping (WockyPing *self);
 static gboolean ping_iq_cb (WockyPorter *porter, WockyStanza *stanza,
     gpointer data);
@@ -68,8 +69,7 @@ static gboolean ping_iq_cb (WockyPorter *porter, WockyStanza *stanza,
 static void
 wocky_ping_init (WockyPing *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_PING,
-      WockyPingPrivate);
+  self->priv = wocky_ping_get_instance_private (self);
 }
 
 static void
@@ -180,9 +180,6 @@ wocky_ping_class_init (WockyPingClass *wocky_ping_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_ping_class);
   GParamSpec *spec;
-
-  g_type_class_add_private (wocky_ping_class,
-      sizeof (WockyPingPrivate));
 
   object_class->constructed = wocky_ping_constructed;
   object_class->set_property = wocky_ping_set_property;

--- a/wocky/wocky-resource-contact.c
+++ b/wocky/wocky-resource-contact.c
@@ -48,8 +48,6 @@
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_ROSTER
 #include "wocky-debug-internal.h"
 
-G_DEFINE_TYPE (WockyResourceContact, wocky_resource_contact, WOCKY_TYPE_CONTACT)
-
 /* properties */
 enum
 {
@@ -76,11 +74,13 @@ struct _WockyResourceContactPrivate
   WockyBareContact *bare_contact;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyResourceContact, wocky_resource_contact,
+    WOCKY_TYPE_CONTACT, G_ADD_PRIVATE (WockyResourceContact))
+
 static void
 wocky_resource_contact_init (WockyResourceContact *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_RESOURCE_CONTACT,
-      WockyResourceContactPrivate);
+  self->priv = wocky_resource_contact_get_instance_private (self);
 }
 
 static void
@@ -183,9 +183,6 @@ wocky_resource_contact_class_init (
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_resource_contact_class);
   WockyContactClass *contact_class = WOCKY_CONTACT_CLASS (wocky_resource_contact_class);
   GParamSpec *spec;
-
-  g_type_class_add_private (wocky_resource_contact_class,
-      sizeof (WockyResourceContactPrivate));
 
   object_class->constructed = wocky_resource_contact_constructed;
   object_class->set_property = wocky_resource_contact_set_property;

--- a/wocky/wocky-sasl-digest-md5.c
+++ b/wocky/wocky-sasl-digest-md5.c
@@ -20,10 +20,6 @@ typedef enum {
 static void
 auth_handler_iface_init (gpointer g_iface);
 
-G_DEFINE_TYPE_WITH_CODE (WockySaslDigestMd5, wocky_sasl_digest_md5,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (
-        WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
-
 enum
 {
   PROP_SERVER = 1,
@@ -39,6 +35,10 @@ struct _WockySaslDigestMd5Private
   gchar *server;
   gchar *digest_md5_rspauth;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockySaslDigestMd5, wocky_sasl_digest_md5,
+    G_TYPE_OBJECT, G_ADD_PRIVATE (WockySaslDigestMd5)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
 
 static void
 wocky_sasl_digest_md5_get_property (
@@ -115,8 +115,6 @@ wocky_sasl_digest_md5_class_init (
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (WockySaslDigestMd5Private));
-
   object_class->dispose = wocky_sasl_digest_md5_dispose;
   object_class->set_property = wocky_sasl_digest_md5_set_property;
   object_class->get_property = wocky_sasl_digest_md5_get_property;
@@ -159,8 +157,7 @@ auth_handler_iface_init (gpointer g_iface)
 static void
 wocky_sasl_digest_md5_init (WockySaslDigestMd5 *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
-      WOCKY_TYPE_SASL_DIGEST_MD5, WockySaslDigestMd5Private);
+  self->priv = wocky_sasl_digest_md5_get_instance_private (self);
   self->priv->state = WOCKY_SASL_DIGEST_MD5_STATE_STARTED;
 }
 

--- a/wocky/wocky-sasl-plain.c
+++ b/wocky/wocky-sasl-plain.c
@@ -12,9 +12,6 @@
 static void
 auth_handler_iface_init (gpointer g_iface);
 
-G_DEFINE_TYPE_WITH_CODE (WockySaslPlain, wocky_sasl_plain, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
-
 enum
 {
   PROP_USERNAME = 1,
@@ -26,6 +23,10 @@ struct _WockySaslPlainPrivate
   gchar *username;
   gchar *password;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockySaslPlain, wocky_sasl_plain, G_TYPE_OBJECT,
+    G_ADD_PRIVATE (WockySaslPlain)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, auth_handler_iface_init))
 
 static void
 wocky_sasl_plain_get_property (GObject *object, guint property_id,
@@ -89,8 +90,6 @@ wocky_sasl_plain_class_init (WockySaslPlainClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (WockySaslPlainPrivate));
-
   object_class->get_property = wocky_sasl_plain_get_property;
   object_class->set_property = wocky_sasl_plain_set_property;
   object_class->dispose = wocky_sasl_plain_dispose;
@@ -124,8 +123,7 @@ auth_handler_iface_init (gpointer g_iface)
 static void
 wocky_sasl_plain_init (WockySaslPlain *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (
-      self, WOCKY_TYPE_SASL_PLAIN, WockySaslPlainPrivate);
+  self->priv = wocky_sasl_plain_get_instance_private (self);
 }
 
 WockySaslPlain *

--- a/wocky/wocky-sasl-scram.c
+++ b/wocky/wocky-sasl-scram.c
@@ -41,10 +41,6 @@ typedef enum {
 static void
 sasl_handler_iface_init (gpointer g_iface);
 
-G_DEFINE_TYPE_WITH_CODE (WockySaslScram, wocky_sasl_scram,
-    G_TYPE_OBJECT, G_IMPLEMENT_INTERFACE (
-        WOCKY_TYPE_AUTH_HANDLER, sasl_handler_iface_init))
-
 enum
 {
   PROP_SERVER = 1,
@@ -72,6 +68,10 @@ struct _WockySaslScramPrivate
 
   GByteArray *salted_password;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockySaslScram, wocky_sasl_scram,
+    G_TYPE_OBJECT, G_ADD_PRIVATE (WockySaslScram)
+    G_IMPLEMENT_INTERFACE (WOCKY_TYPE_AUTH_HANDLER, sasl_handler_iface_init))
 
 static void
 wocky_sasl_scram_get_property (
@@ -159,8 +159,6 @@ wocky_sasl_scram_class_init (
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (WockySaslScramPrivate));
-
   object_class->dispose = wocky_sasl_scram_dispose;
   object_class->set_property = wocky_sasl_scram_set_property;
   object_class->get_property = wocky_sasl_scram_get_property;
@@ -209,8 +207,7 @@ sasl_handler_iface_init (gpointer g_iface)
 static void
 wocky_sasl_scram_init (WockySaslScram *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
-      WOCKY_TYPE_SASL_SCRAM, WockySaslScramPrivate);
+  self->priv = wocky_sasl_scram_get_instance_private (self);
   self->priv->state = WOCKY_SASL_SCRAM_STATE_STARTED;
 }
 

--- a/wocky/wocky-session.c
+++ b/wocky/wocky-session.c
@@ -45,8 +45,6 @@
 #include "wocky-c2s-porter.h"
 #include "wocky-meta-porter.h"
 
-G_DEFINE_TYPE (WockySession, wocky_session, G_TYPE_OBJECT)
-
 /* properties */
 enum
 {
@@ -77,11 +75,13 @@ struct _WockySessionPrivate
   WockyContactFactory *contact_factory;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockySession, wocky_session, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockySession))
+
 static void
 wocky_session_init (WockySession *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_SESSION,
-      WockySessionPrivate);
+  self->priv = wocky_session_get_instance_private (self);
 
   self->priv->contact_factory = wocky_contact_factory_new ();
 }
@@ -195,9 +195,6 @@ wocky_session_class_init (WockySessionClass *wocky_session_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_session_class);
   GParamSpec *spec;
-
-  g_type_class_add_private (wocky_session_class,
-      sizeof (WockySessionPrivate));
 
   object_class->constructed = wocky_session_constructed;
   object_class->set_property = wocky_session_set_property;

--- a/wocky/wocky-stanza.c
+++ b/wocky/wocky-stanza.c
@@ -33,8 +33,6 @@
 
 #include "wocky-node-private.h"
 
-G_DEFINE_TYPE(WockyStanza, wocky_stanza, WOCKY_TYPE_NODE_TREE)
-
 /* private structure */
 struct _WockyStanzaPrivate
 {
@@ -43,6 +41,9 @@ struct _WockyStanzaPrivate
 
   gboolean dispose_has_run;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyStanza, wocky_stanza, WOCKY_TYPE_NODE_TREE,
+          G_ADD_PRIVATE (WockyStanza))
 
 typedef struct
 {
@@ -139,8 +140,7 @@ static const StanzaSubTypeName sub_type_names[NUM_WOCKY_STANZA_SUB_TYPE] =
 static void
 wocky_stanza_init (WockyStanza *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_STANZA,
-      WockyStanzaPrivate);
+  self->priv = wocky_stanza_get_instance_private (self);
 
   self->priv->from_contact = NULL;
   self->priv->to_contact = NULL;
@@ -153,8 +153,6 @@ static void
 wocky_stanza_class_init (WockyStanzaClass *wocky_stanza_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_stanza_class);
-
-  g_type_class_add_private (wocky_stanza_class, sizeof (WockyStanzaPrivate));
 
   object_class->dispose = wocky_stanza_dispose;
   object_class->finalize = wocky_stanza_finalize;

--- a/wocky/wocky-xmpp-reader.c
+++ b/wocky/wocky-xmpp-reader.c
@@ -59,8 +59,6 @@ enum {
   PROP_ID,
 };
 
-G_DEFINE_TYPE (WockyXmppReader, wocky_xmpp_reader, G_TYPE_OBJECT)
-
 /* Parser prototypes */
 static void _start_element_ns (void *user_data,
     const xmlChar *localname, const xmlChar *prefix, const xmlChar *uri,
@@ -129,6 +127,9 @@ struct _WockyXmppReaderPrivate
   GQueue *stanzas;
   WockyXmppReaderState state;
 };
+
+G_DEFINE_TYPE_WITH_CODE (WockyXmppReader, wocky_xmpp_reader, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyXmppReader))
 
 /**
  * wocky_xmpp_reader_error_quark
@@ -217,8 +218,7 @@ wocky_xmpp_reader_init (WockyXmppReader *self)
 {
   WockyXmppReaderPrivate *priv;
 
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_XMPP_READER,
-      WockyXmppReaderPrivate);
+  self->priv = wocky_xmpp_reader_get_instance_private (self);
   priv = self->priv;
 
   priv->nodes = g_queue_new ();
@@ -242,8 +242,6 @@ wocky_xmpp_reader_class_init (WockyXmppReaderClass *wocky_xmpp_reader_class)
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_xmpp_reader_class);
   GParamSpec *param_spec;
 
-  g_type_class_add_private (wocky_xmpp_reader_class,
-      sizeof (WockyXmppReaderPrivate));
   wocky_xmpp_reader_class->stream_element_name = "stream";
   wocky_xmpp_reader_class->stream_element_ns = WOCKY_XMPP_NS_STREAM;
 
@@ -331,6 +329,8 @@ wocky_xmpp_reader_finalize (GObject *object)
 
   if (priv->error != NULL)
     g_error_free (priv->error);
+
+  g_free (priv->default_namespace);
 
   G_OBJECT_CLASS (wocky_xmpp_reader_parent_class)->finalize (object);
 }

--- a/wocky/wocky-xmpp-writer.c
+++ b/wocky/wocky-xmpp-writer.c
@@ -40,8 +40,6 @@
 
 #include "wocky-xmpp-writer.h"
 
-G_DEFINE_TYPE (WockyXmppWriter, wocky_xmpp_writer, G_TYPE_OBJECT)
-
 #define WOCKY_DEBUG_FLAG WOCKY_DEBUG_XMPP_WRITER
 #include "wocky-debug-internal.h"
 
@@ -61,13 +59,15 @@ struct _WockyXmppWriterPrivate
   xmlBufferPtr buffer;
 };
 
+G_DEFINE_TYPE_WITH_CODE (WockyXmppWriter, wocky_xmpp_writer, G_TYPE_OBJECT,
+          G_ADD_PRIVATE (WockyXmppWriter))
+
 static void
 wocky_xmpp_writer_init (WockyXmppWriter *self)
 {
   WockyXmppWriterPrivate *priv;
 
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, WOCKY_TYPE_XMPP_WRITER,
-      WockyXmppWriterPrivate);
+  self->priv = wocky_xmpp_writer_get_instance_private (self);
   priv = self->priv;
 
   priv->current_ns = 0;
@@ -94,9 +94,6 @@ wocky_xmpp_writer_class_init (WockyXmppWriterClass *wocky_xmpp_writer_class)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (wocky_xmpp_writer_class);
   GParamSpec *param_spec;
-
-  g_type_class_add_private (wocky_xmpp_writer_class,
-      sizeof (WockyXmppWriterPrivate));
 
   object_class->dispose = wocky_xmpp_writer_dispose;
   object_class->finalize = wocky_xmpp_writer_finalize;


### PR DESCRIPTION
Major changes (which were blockers to switch to the latest Glib API):
 * Switch to G_ADD_PRIVATE and *_get_instance_private to define and assign object instance's private struct.
 * Switch to GTask from deprecated GSimpleAsyncResult for async operations. GTask has a bit different asynchronous execution order.

closes #11 