### PR TITLE
Add Meson build system

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,33 @@ on:
   pull_request:
 
 jobs:
-  syntax_check:
+  build-meson:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install prereqs
+      run: |-
+        sudo apt-get update && sudo apt-get install --no-install-recommends -qq -y build-essential \
+        ccache meson libglib2.0-dev glib-networking telepathy-gabble libsasl2-dev libxml2-dev \
+        libsoup2.4-dev libsasl2-modules-gssapi-mit gnutls-bin libsqlite3-dev libssl-dev libgnutls28-dev
+    - name: Bootstrap
+      run: meson _b
+    - name: Syntax
+      run: ninja -C _b check
+    - name: Build
+      run: ninja -C _b
+    - name: Run tests
+      run: meson test -C _b
+    - name: Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Reports
+        path: _b/meson-logs/
+
+  build-autotools:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - name: Install prereqs
@@ -21,24 +45,6 @@ jobs:
       run: make -C wocky check-local
     - name: Test Syntax Check
       run: make -C tests check-coding-style
-
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: wocky/.libs
-        key: ${{ github.sha }}
-    - name: Install prereqs
-      run: |-
-        sudo apt-get update && sudo apt-get install --no-install-recommends -qq -y build-essential \
-        ccache automake libtool libglib2.0-dev glib-networking telepathy-gabble libsasl2-dev \
-        libxml2-dev libsoup2.4-dev libsasl2-modules-gssapi-mit gnutls-bin libsqlite3-dev \
-        libssl-dev libgnutls28-dev
-    - name: Bootstrap
-      run: bash autogen.sh
     - name: Build
       run: make
     - name: Run TLSv1.3 test
@@ -48,4 +54,3 @@ jobs:
       with:
         name: Reports
         path: tests/test*report.xml
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,29 +4,41 @@ stages:
   - test
 
 variables:
-  FEDORA_IMG: registry.freedesktop.org/telepathy/wocky/master:v1
-  DEBIAN_IMG: registry.freedesktop.org/telepathy/wocky/debtest:v1
-  DEBSTB_IMG: registry.freedesktop.org/telepathy/wocky/debstbl:v1
-  SUSELP_IMG: registry.freedesktop.org/telepathy/wocky/osuselp:v1
-  SUSETW_IMG: registry.freedesktop.org/telepathy/wocky/osusetw:v1
+  FEDORA_AC: registry.freedesktop.org/telepathy/wocky/master:v1
+  DEBIAN_AC: registry.freedesktop.org/telepathy/wocky/debtest:v1
+  DEBSTB_AC: registry.freedesktop.org/telepathy/wocky/debstbl:v1
+  SUSELP_AC: registry.freedesktop.org/telepathy/wocky/osuselp:v1
+  SUSETW_AC: registry.freedesktop.org/telepathy/wocky/osusetw:v1
+  FEDORA_MB: registry.freedesktop.org/telepathy/telepathy-gabble/fedoraw:v1
+  DEBIAN_MB: registry.freedesktop.org/telepathy/telepathy-gabble/debtest:v1
+  DEBSTB_MB: registry.freedesktop.org/telepathy/telepathy-gabble/debstbl:v1
+  SUSELP_MB: registry.freedesktop.org/telepathy/telepathy-gabble/osuselp:v1
+  SUSETW_MB: registry.freedesktop.org/telepathy/telepathy-gabble/osusetw:v1
   WOCKY_DEBUG: all
   #G_MESSAGES_DEBUG: all
 
-.default:
+.def_ac:
   before_script:
     - bash autogen.sh
   cache:
     key: "$CI_JOB_IMAGE:$CI_COMMIT_SHA"
     untracked: true
 
+.def_mb:
+  before_script:
+    - test -d _b || meson _b -Dgoogle-relay=true
+  cache:
+    key: "$CI_JOB_IMAGE:$CI_COMMIT_SHA"
+    untracked: true
+
 .defbuild:
-  extends: .default
+  extends: .def_ac
   stage: build
   script:
     - make
 
 .deftest:
-  extends: .default
+  extends: .def_ac
   stage: test
   script:
     - make check
@@ -36,49 +48,78 @@ variables:
       - "tests/test-old-report.xml"
       - "tests/test-new-report.xml"
 
-style-check:
-  image: $FEDORA_IMG
-  extends: .default
+style-ck-ac:
+  extends: .def_ac
   stage: style-check
+  image: $FEDORA_AC
   script:
     - make -C wocky check-local
+    - make -C tests check-coding-style
 
-fedora-x86_64-build:
-  image: $FEDORA_IMG
+style-ck-mb:
+  extends: .def_mb
+  stage: style-check
+  image: $FEDORA_MB
+  script:
+    - ninja -C _b check
+
+build-ac:
   extends: .defbuild
+  image: $image
+  parallel:
+    matrix:
+      - image:
+        - $FEDORA_AC
+        #- $DEBIAN_AC
+        - $SUSETW_AC
+        - $DEBSTB_AC
+        - $SUSELP_AC
 
-fedora-x86_64-test:
-  image: $FEDORA_IMG
+build-mb:
+  extends: .def_mb
+  stage: build
+  image: $image
+  script:
+    - ninja -C _b
+  parallel:
+    matrix:
+      - image:
+        - $FEDORA_MB
+        - $DEBIAN_MB
+        #- $SUSETW_MB
+        - $DEBSTB_MB
+        - $SUSELP_MB
+
+test-ac:
   extends: .deftest
+  image: $image
+  parallel:
+    matrix:
+      - image:
+        - $FEDORA_AC
+        #- $DEBIAN_AC
+        - $SUSETW_AC
+        - $DEBSTB_AC
+        - $SUSELP_AC
 
-debian-x86_64-build:
-  image: $DEBIAN_IMG
-  extends: .defbuild
+test-mb:
+  extends: .def_mb
+  stage: test
+  image: $image
+  script:
+    - meson test -C _b
+  artifacts:
+    reports:
+    expire_in: 1 week
+    when: always
+    paths:
+      - "_b/meson-logs"
+  parallel:
+    matrix:
+      - image:
+        - $FEDORA_MB
+        - $DEBIAN_MB
+        #- $SUSETW_MB
+        - $DEBSTB_MB
+        - $SUSELP_MB
 
-debian-x86_64-test:
-  image: $DEBIAN_IMG
-  extends: .deftest
-
-opensuse-x86_64-build:
-  image: $SUSETW_IMG
-  extends: .defbuild
-
-opensuse-x86_64-test:
-  image: $SUSETW_IMG
-  extends: .deftest
-
-debian-stable-x86_64-build:
-  image: $DEBSTB_IMG
-  extends: .defbuild
-
-debian-stable-x86_64-test:
-  image: $DEBSTB_IMG
-  extends: .deftest
-
-opensuse-stable-x86_64-build:
-  image: $SUSELP_IMG
-  extends: .defbuild
-
-opensuse-stable-x86_64-test:
-  image: $SUSELP_IMG
-  extends: .deftest

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,172 @@
+project(
+  'wocky','c',
+  license: 'LGPL2.1+',
+  version: '0.19.0',
+  meson_version: '>= 0.49.0',
+  default_options: ['c_std=c99', 'warning_level=2', 'werror=true']
+)
+
+prefix = get_option('prefix')
+libdir = get_option('libdir')
+includedir = get_option('includedir')
+
+if get_option('install-headers') != ''
+  includedir = includedir/get_option('install-headers')
+endif
+
+if get_option('libdir-suffix') != ''
+  libdir = libdir / get_option('libdir-suffix')
+endif
+
+# compiler flags
+common_flags = [
+  '-D_GNU_SOURCE',
+  '-DHAVE_CONFIG_H',
+  '-DG_LOG_USE_STRUCTURED',
+]
+add_project_arguments(common_flags, language: 'c')
+
+# compiler specific flags
+werr_cflags = []
+warn_errs = [
+  #  'all',
+  #  'extra',
+  'declaration-after-statement',
+  'implicit-function-declaration',
+  'shadow',
+  'strict-prototypes',
+  'missing-prototypes',
+  'sign-compare',
+  'nested-externs',
+  'pointer-arith',
+  'format',
+  'format-security',
+  'init-self'
+]
+no_warn_errs = [
+  'missing-field-initializers',
+  'cast-function-type',
+  'unused-parameter'
+]
+foreach e: warn_errs
+  werr_cflags += '-W@0@'.format(e)
+endforeach
+
+## covered by werror=true
+#werr_cflags += '-Werror'
+
+foreach e: no_warn_errs
+  werr_cflags += '-Wno-@0@'.format(e)
+  werr_cflags += '-Wno-error=@0@'.format(e)
+endforeach
+
+cc = meson.get_compiler('c')
+add_project_arguments(cc.get_supported_arguments(werr_cflags), language: 'c')
+
+# dependencies
+glib_dep    = dependency('glib-2.0',    version: '>= 2.52',
+  fallback: ['glib', 'libglib_dep'])
+gio_dep     = dependency('gio-2.0',     version: '>= 2.52',
+  fallback: ['glib', 'libgio_dep'])
+gobj_dep    = dependency('gobject-2.0',
+  fallback: ['glib', 'gobj_dep'])
+gmod_dep    = dependency('gmodule-2.0',
+  fallback: ['glib', 'gmod_dep'])
+libxml2_dep = dependency('libxml-2.0')
+sqlite3_dep = dependency('sqlite3')
+libsasl_dep = dependency('libsasl2', required: false)
+libiphb_dep = dependency('libiphb', version: '>= 0.61.31', required: false)
+libsoup_dep = dependency('libsoup-2.4', version: '>= 2.42', required: get_option('google-relay'))
+
+certtool = find_program('certtool', required: false)
+
+# configuration
+conf = configuration_data()
+conf_h = ''
+defines = []
+
+check_h = [
+  'dlfcn.h',
+  'inttypes.h',
+  'memory.h',
+  'stdint.h',
+  'stdlib.h',
+  'unistd.h',
+  'string.h',
+  'strings.h',
+  'sys/stat.h',
+  'sys/types.h'
+]
+
+foreach h: check_h
+  if cc.has_header(h)
+    define = 'HAVE_' + h.underscorify().to_upper()
+    defines += define
+  endif
+endforeach
+
+if get_option('debug')
+  defines += 'ENABLE_DEBUG'
+endif
+
+if get_option('google-relay')
+  defines += 'ENABLE_GOOGLE_RELAY'
+endif
+
+if libiphb_dep.found()
+  defines += 'HAVE_LIBIPHB'
+endif
+
+if libsasl_dep.found()
+  defines += 'HAVE_LIBSASL2'
+endif
+
+foreach define: defines
+  conf.set(define, 1)
+  conf_h += '#define @0@ 1\n'.format(define)
+endforeach
+
+config_h = configure_file(
+  output: 'config.h',
+  configuration: conf
+)
+
+gnome = import('gnome')
+pymod = import('python')
+python = pymod.find_installation()
+
+shell = find_program('sh')
+
+# Introspection
+gir = find_program('g-ir-scanner', required : get_option('introspection').enabled())
+build_gir = gir.found() and not meson.is_cross_build() and get_option('introspection').enabled()
+
+output = '\nConfigure summary\n\n'
+output += '  Prefix:              ' + prefix + '\n'
+output += '  Libdir:              ' + libdir + '\n'
+output += '  Install includes:    ' + includedir + '\n'
+#output += '  Coverage profiling:  ' + gcov_dep.found().to_string() + '\n'
+output += '  Coding style checks: ' + get_option('code-style-check').to_string() + '\n'
+output += '  Debug:               ' + get_option('debug').to_string() + '\n\n'
+output += 'Features:\n'
+output += '  Has GnuTLS:          ' + certtool.found().to_string() + '\n'
+output += '  SASL2 Tests:         ' + libsasl_dep.found().to_string() + '\n'
+output += '  libiphb integration: ' + libiphb_dep.found().to_string() + '\n'
+output += '  google jingle relay: ' + get_option('google-relay').to_string() + '\n'
+output += '  gtk-doc generation:  ' + get_option('gtk_doc').to_string() +'\n'
+output += '  g-ir generation:     ' + build_gir.to_string() +'\n'
+message(output)
+
+wocky_inc = include_directories('wocky')
+wocky_dep_inc = '-I'+meson.current_source_dir()
+wocky_conf_inc = include_directories('.')
+
+wocky_check_files = []
+subdir('wocky')
+subdir('tests')
+
+if get_option('code-style-check')
+  run_target('check', command: [
+    shell, meson.source_root()/'tools'/'check-c-style.sh', wocky_check_files
+  ])
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option('gtk_doc', type: 'boolean', value: false, description: 'Enable Gtk-Doc generation')
+option('introspection', type: 'feature', value: 'auto', description: 'Build Introspection data')
+option('code-style-check', type: 'boolean', description: 'enable coding style checks')
+option('install-headers', type: 'string', description: 'install development headers here')
+option('libdir-suffix', type: 'string', description: 'install a shared library into project-specific subdir')
+option('google-relay', type: 'boolean', value: false, description: 'enable google jingle relay support')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,253 @@
+
+TEST_DIR = meson.current_source_dir()
+CERT_DIR = TEST_DIR / 'certs'
+CA_DIR = CERT_DIR / 'cas'
+CRL_DIR = CERT_DIR / 'crl'
+
+keys = {
+  'CA_KEY': 'ca-0-key.pem',
+  'SS_KEY': 'ss-key.pem',
+  'REV_KEY': 'rev-key.pem',
+  'EXP_KEY': 'exp-key.pem',
+  'NEW_KEY': 'new-key.pem',
+  'INS_KEY': 'ins-key.pem',
+  'WILD_KEY': 'wild-key.pem',
+  'SERVER_KEY': 'tls-key.pem',
+  'BADWILD_KEY': 'badwild-key.pem',
+  'UNKNOWN_KEY': 'unknown-key.pem'
+}
+certs = {
+  'CA_CRT': 'ca-0-cert.pem',
+  'SS_CRT': 'ss-cert.pem',
+  'REV_CRT': 'rev-cert.pem',
+  'EXP_CRT': 'exp-cert.pem',
+  'NEW_CRT': 'new-cert.pem',
+  'INS_CRT': 'ins-cert.pem',
+  'WILD_CRT': 'wild-cert.pem',
+  'SERVER_CRT': 'tls-cert.pem',
+  'BADWILD_CRT': 'badwild-cert.pem',
+  'UNKNOWN_CRT': 'unknown-cert.pem'
+}
+
+tests = {
+  'wocky-bare-contact-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-bare-contact-test.c',
+  ],
+  'wocky-caps-hash-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-caps-hash-test.c',
+  ],
+  'wocky-connector-test': [
+    'wocky-test-sasl-auth-server.c',
+    'wocky-test-sasl-auth-server.h',
+    'wocky-test-connector-server.c',
+    'wocky-test-connector-server.h',
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'test-resolver.c', 'test-resolver.h',
+    'wocky-connector-test.c',
+  ],
+  'wocky-contact-factory-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-contact-factory-test.c',
+  ],
+  'wocky-data-form-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-data-form-test.c',
+  ],
+  'wocky-jid-validation-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-jid-validation-test.c',
+  ],
+  'wocky-loopback-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-loopback-test.c',
+  ],
+  'wocky-node-tree-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-node-tree-test.c',
+  ],
+  'wocky-pep-service-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-pep-service-test.c',
+  ],
+  'wocky-ping-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-ping-test.c',
+  ],
+  'wocky-porter-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-porter-test.c',
+  ],
+  'wocky-pubsub-node-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-pubsub-test-helpers.c', 'wocky-pubsub-test-helpers.h',
+    'wocky-pubsub-node-test.c',
+  ],
+  'wocky-pubsub-service-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-pubsub-test-helpers.c', 'wocky-pubsub-test-helpers.h',
+    'wocky-pubsub-service-test.c',
+  ],
+  'wocky-resource-contact-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-resource-contact-test.c',
+  ],
+  'wocky-roster-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-roster-test.c',
+  ],
+  'wocky-sasl-utils-test': [
+    'wocky-sasl-utils-test.c',
+  ],
+  'wocky-scram-sha1-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-scram-sha1-test.c',
+  ],
+  'wocky-test-sasl-auth': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-test-sasl-handler.c',
+    'wocky-test-sasl-handler.h',
+    'wocky-test-sasl-auth-server.c',
+    'wocky-test-sasl-auth-server.h',
+    'wocky-test-sasl-auth.c',
+  ],
+  'wocky-session-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-session-test.c',
+  ],
+  'wocky-stanza-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-stanza-test.c',
+  ],
+  'wocky-tls-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-tls-test.c',
+  ],
+  'wocky-utils-test': [
+    'wocky-utils-test.c',
+  ],
+  'wocky-xmpp-connection-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-xmpp-connection-test.c',
+  ],
+  'wocky-xmpp-node-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-xmpp-node-test.c',
+  ],
+  'wocky-xmpp-reader-test': [
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-xmpp-reader-test.c',
+  ],
+  'wocky-xmpp-readwrite-test': [
+    'wocky-test-stream.c', 'wocky-test-stream.h',
+    'wocky-test-helper.c', 'wocky-test-helper.h',
+    'wocky-xmpp-readwrite-test.c',
+  ],
+}
+
+dummy_server_src = [
+  'wocky-dummy-xmpp-server.c',
+  'wocky-test-connector-server.c', 'wocky-test-connector-server.h',
+  'wocky-test-helper.c', 'wocky-test-helper.h',
+  'wocky-test-stream.c', 'wocky-test-stream.h',
+  'wocky-test-sasl-auth-server.c', 'wocky-test-sasl-auth-server.h',
+]
+
+test_deps = wocky_deps + [ wocky_dep ]
+
+if libsasl_dep.found()
+  test_deps += libsasl_dep
+endif
+
+tls_cflags = [
+  '-DTLS_CA_DIR="@0@"'.format(CA_DIR),
+  '-DTLS_CRL_DIR="@0@"'.format(CRL_DIR)
+]
+
+foreach key, file: keys
+  path = CERT_DIR / file
+  tls_cflags += '-DTLS_@0@_FILE="@1@"'.format(key, path)
+endforeach
+
+foreach cert, file: certs
+  path = CERT_DIR / file
+  tls_cflags += '-DTLS_@0@_FILE="@1@"'.format(cert, path)
+endforeach
+
+test_cflags = ['-DG_LOG_DOMAIN="Wocky-Test"' ]
+
+tls_progs = ['wocky-connector-test','wocky-sm-test', 'wocky-tls-test']
+sasl_progs = ['wocky-connector-test', 'wocky-sm-test', 'wocky-test-sasl-auth']
+
+executable('wocky-dummy-xmpp-server', files(dummy_server_src),
+  dependencies: test_deps,
+  include_directories: [ wocky_conf_inc ],
+  c_args: [ test_cflags, tls_cflags],
+  link_with: wocky_so)
+
+check_src = []
+foreach prog, src: tests
+  prog_cflags = test_cflags
+  prog_deps = test_deps
+  if get_option('code-style-check')
+    foreach file: src
+      if file not in check_src
+        check_src += file
+      endif
+    endforeach
+  endif
+  if prog in tls_progs
+    prog_cflags += tls_cflags
+  endif
+  exe = executable(prog, files(src),
+    dependencies: prog_deps,
+    include_directories: [ wocky_conf_inc ],
+    c_args: prog_cflags,
+    link_with: wocky_so)
+  test(prog, exe,
+    is_parallel: prog not in sasl_progs,
+    env: [
+      'WOCKY_CHANNEL_BINDING_TYPE=tls-exporter'
+    ])
+  if prog == 'wocky-connector-test'
+    test(prog+'-tls1.2', exe,
+      is_parallel: false,
+      env: [
+        'G_TLS_GNUTLS_PRIORITY=NORMAL:%COMPAT:-VERS-TLS1.3',
+        'G_TLS_OPENSSL_MAX_PROTO=0x0303'
+      ])
+  endif
+endforeach
+
+if get_option('code-style-check')
+  foreach file: dummy_server_src
+    if file not in check_src
+      check_src += file
+    endif
+  endforeach
+  wocky_check_files += files(check_src)
+endif

--- a/tools/check-c-style.sh
+++ b/tools/check-c-style.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 fail=0
 
+if [ -n "$MESON_SOURCE_ROOT" ]; then
+  tools_dir="$MESON_SOURCE_ROOT/tools"
+fi
+
 ( . "${tools_dir}"/check-misc.sh ) || fail=$?
 
 if grep -n '^ *GError *\*[[:alpha:]_][[:alnum:]_]* *;' "$@"

--- a/tools/gen_marshal_list.py
+++ b/tools/gen_marshal_list.py
@@ -1,0 +1,23 @@
+#!/bin/env python
+
+import sys
+import re
+
+rex = re.compile('.*_wocky_signals_marshal_([A-Z0-9]*__[A-Z0-9_]*).*')
+
+src = sys.argv[1:-1]
+out = sys.argv[-1]
+
+proto = set()
+
+for fn in src:
+  f = open(fn)
+  for line in f:
+    for m in rex.finditer(line):
+      proto.add(m.group(1))
+  f.close()
+
+with open(out,'w') as f:
+  for call in proto:
+    f.write(call.replace('__',':').replace('_',',') + "\n")
+

--- a/wocky/meson.build
+++ b/wocky/meson.build
@@ -1,0 +1,237 @@
+
+handwritten_headers = files(
+  'wocky.h',
+  'wocky-auth-handler.h',
+  'wocky-auth-registry.h',
+  'wocky-bare-contact.h',
+  'wocky-c2s-porter.h',
+  'wocky-caps-cache.h',
+  'wocky-ll-connection-factory.h',
+  'wocky-caps-hash.h',
+  'wocky-connector.h',
+  'wocky-contact.h',
+  'wocky-contact-factory.h',
+  'wocky-data-form.h',
+  'wocky-debug.h',
+  'wocky-disco-identity.h',
+  'wocky-google-relay.h',
+  'wocky-jabber-auth.h',
+  'wocky-jabber-auth-digest.h',
+  'wocky-jabber-auth-password.h',
+  'wocky-jingle-content.h',
+  'wocky-jingle-factory.h',
+  'wocky-jingle-info-internal.h',
+  'wocky-jingle-info.h',
+  'wocky-jingle-media-rtp.h',
+  'wocky-jingle-session.h',
+  'wocky-jingle-transport-google.h',
+  'wocky-jingle-transport-iceudp.h',
+  'wocky-jingle-transport-iface.h',
+  'wocky-jingle-transport-rawudp.h',
+  'wocky-jingle-types.h',
+  'wocky-ll-connector.h',
+  'wocky-ll-contact.h',
+  'wocky-loopback-stream.h',
+  'wocky-meta-porter.h',
+  'wocky-muc.h',
+  'wocky-namespaces.h',
+  'wocky-node.h',
+  'wocky-node-tree.h',
+  'wocky-pep-service.h',
+  'wocky-ping.h',
+  'wocky-porter.h',
+  'wocky-pubsub-helpers.h',
+  'wocky-pubsub-node.h',
+  'wocky-pubsub-node-protected.h',
+  'wocky-pubsub-service.h',
+  'wocky-pubsub-service-protected.h',
+  'wocky-resource-contact.h',
+  'wocky-roster.h',
+  'wocky-sasl-auth.h',
+  'wocky-sasl-utils.h',
+  'wocky-sasl-digest-md5.h',
+  'wocky-sasl-scram.h',
+  'wocky-sasl-plain.h',
+  'wocky-session.h',
+  'wocky-stanza.h',
+  'wocky-tls.h',
+  'wocky-tls-handler.h',
+  'wocky-tls-connector.h',
+  'wocky-types.h',
+  'wocky-utils.h',
+  'wocky-xep-0115-capabilities.h',
+  'wocky-xmpp-connection.h',
+  'wocky-xmpp-error.h',
+  'wocky-xmpp-reader.h',
+  'wocky-xmpp-writer.h'
+)
+
+handwritten_sources = files(
+  'wocky.c',
+  'wocky-auth-handler.c',
+  'wocky-auth-registry.c',
+  'wocky-bare-contact.c',
+  'wocky-c2s-porter.c',
+  'wocky-caps-cache.c',
+  'wocky-ll-connection-factory.c',
+  'wocky-caps-hash.c',
+  'wocky-connector.c',
+  'wocky-contact.c',
+  'wocky-contact-factory.c',
+  'wocky-data-form.c',
+  'wocky-debug.c',
+  'wocky-debug-internal.h',
+  'wocky-disco-identity.c',
+  'wocky-heartbeat-source.c',
+  'wocky-heartbeat-source.h',
+  'wocky-google-relay.c',
+  'wocky-jabber-auth.c',
+  'wocky-jabber-auth-digest.c',
+  'wocky-jabber-auth-password.c',
+  'wocky-jingle-content.c',
+  'wocky-jingle-factory.c',
+  'wocky-jingle-info.c',
+  'wocky-jingle-media-rtp.c',
+  'wocky-jingle-session.c',
+  'wocky-jingle-transport-google.c',
+  'wocky-jingle-transport-iceudp.c',
+  'wocky-jingle-transport-iface.c',
+  'wocky-jingle-transport-rawudp.c',
+  'wocky-ll-connector.c',
+  'wocky-ll-contact.c',
+  'wocky-loopback-stream.c',
+  'wocky-meta-porter.c',
+  'wocky-muc.c',
+  'wocky-node.c',
+  'wocky-node-private.h',
+  'wocky-node-tree.c',
+  'wocky-pep-service.c',
+  'wocky-ping.c',
+  'wocky-porter.c',
+  'wocky-pubsub-helpers.c',
+  'wocky-pubsub-node.c',
+  'wocky-pubsub-node-internal.h',
+  'wocky-pubsub-service.c',
+  'wocky-resource-contact.c',
+  'wocky-roster.c',
+  'wocky-sasl-auth.c',
+  'wocky-sasl-digest-md5.c',
+  'wocky-sasl-scram.c',
+  'wocky-sasl-utils.c',
+  'wocky-sasl-plain.c',
+  'wocky-session.c',
+  'wocky-stanza.c',
+  'wocky-utils.c',
+  'wocky-tls.c',
+  'wocky-tls-common.c',
+  'wocky-tls-handler.c',
+  'wocky-tls-connector.c',
+  'wocky-xep-0115-capabilities.c',
+  'wocky-xmpp-connection.c',
+  'wocky-xmpp-error.c',
+  'wocky-xmpp-reader.c',
+  'wocky-xmpp-writer.c'
+)
+
+if get_option('code-style-check')
+  wocky_check_files += handwritten_sources
+  wocky_check_files += handwritten_headers
+endif
+
+enumtype_sources = [
+  'wocky-auth-registry.h',
+  'wocky-connector.h',
+  'wocky-data-form.h',
+  'wocky-jingle-info-internal.h',
+  'wocky-jingle-types.h',
+  'wocky-muc.h',
+  'wocky-pubsub-node.h',
+  'wocky-pubsub-service.h',
+  'wocky-tls.h',
+  'wocky-xmpp-error.h',
+  'wocky-xmpp-reader.h'
+  ]
+
+wocky_marshal_list = 'wocky-signals-marshal.list'
+wocky_marshal_src = custom_target('wocky-signals-marshal',
+  input: handwritten_sources,
+  output: wocky_marshal_list,
+  command: [python, meson.current_source_dir()/'..'/'tools'/'gen_marshal_list.py', '@INPUT@', '@OUTPUT@' ]
+)
+wocky_marshals = gnome.genmarshal('wocky-signals-marshal',
+  sources: [wocky_marshal_src],
+  install_header: (includedir != ''),
+  install_dir: includedir/meson.project_name(),
+  prefix: '_@0@_signals_marshal'.format(meson.project_name()))
+
+wocky_enums = gnome.mkenums_simple('wocky-enumtypes',
+  body_prefix: '#include "config.h"',
+  install_header: (includedir != ''),
+  install_dir: includedir/meson.project_name(),
+  sources: enumtype_sources
+)
+
+wocky_sources = [
+  handwritten_sources,
+  handwritten_headers,
+  wocky_marshals,
+  wocky_enums,
+]
+
+wocky_deps = [glib_dep, gio_dep, gobj_dep, gmod_dep, sqlite3_dep, libxml2_dep ]
+
+if libiphb_dep.found()
+  wocky_deps += libiphb_dep
+endif
+
+if libsoup_dep.found()
+  wocky_deps += libsoup_dep
+endif
+
+wocky_cflags = ['-DG_LOG_DOMAIN="wocky"', '-DWOCKY_COMPILATION']
+wocky_ldflags = []
+
+wocky_ldflags += cc.get_supported_link_arguments(['-Wl,--no-undefined'])
+
+install_headers(handwritten_headers,
+  install_dir: includedir/meson.project_name())
+
+wocky_so = library(
+  meson.project_name(), wocky_sources,
+  install: true,
+  install_dir: libdir,
+  version: meson.project_version(),
+  dependencies: wocky_deps,
+  include_directories: [wocky_inc, wocky_conf_inc],
+  c_args: wocky_cflags,
+  link_args: wocky_ldflags
+)
+
+pkg = import('pkgconfig')
+pkg.generate(wocky_so,
+  filebase: meson.project_name(),
+  subdirs: get_option('install-headers'),
+)
+
+
+gir = find_program('g-ir-scanner', required: get_option('introspection').enabled())
+if gir.found()
+  wocky_gir = gnome.generate_gir(wocky_so,
+    sources: [handwritten_headers, handwritten_sources, wocky_marshals, wocky_enums],
+    dependencies: wocky_deps,
+    namespace: 'Wocky',
+    nsversion: '0',
+    symbol_prefix: ['wocky'],
+    header: 'wocky.h',
+    install: build_gir,
+    extra_args: wocky_cflags
+  )
+endif
+
+wocky_dep = declare_dependency(
+  dependencies: wocky_deps,
+  sources: [ wocky_enums[1], wocky_marshals[1] ],
+  compile_args: wocky_dep_inc,
+  include_directories: wocky_inc,
+  link_with: wocky_so,
+  link_args: wocky_ldflags)

--- a/wocky/wocky-tls.c
+++ b/wocky/wocky-tls.c
@@ -95,7 +95,7 @@ wocky_tls_session_add_ca (GTlsConnection *conn,
        * new value.
        */
       for (c = cas; c; c = c->next)
-	g_object_ref (c->data);
+        g_object_ref (c->data);
       cas = g_list_copy (cas);
     }
   DEBUG ("adding CA CERT path '%s'", (gchar *) ca_path);
@@ -120,11 +120,11 @@ wocky_tls_session_add_ca (GTlsConnection *conn,
           gchar *path = g_build_path ("/", ca_path, entry->d_name, NULL);
 
           if ((stat (path, &file) == 0) && S_ISREG (file.st_mode))
-	    {
-	      certs = g_tls_certificate_list_new_from_file (path, NULL);
-	      n += g_list_length (certs);
-	      cas = g_list_concat (cas, certs);
-	    }
+            {
+              certs = g_tls_certificate_list_new_from_file (path, NULL);
+              n += g_list_length (certs);
+              cas = g_list_concat (cas, certs);
+            }
 
           g_free (path);
         }
@@ -158,7 +158,7 @@ wocky_tls_session_add_ca (GTlsConnection *conn,
               g_free (buf);
               break;
             }
-	  g_free (buf);
+          g_free (buf);
         }
       g_io_stream_close (G_IO_STREAM (fio), NULL, NULL);
       if (o)
@@ -202,16 +202,16 @@ wocky_tls_session_get_peers_certificate (GTlsConnection *conn,
       GByteArray *der_data;
 
       g_object_get (G_OBJECT (tlscert),
-		    "certificate", &der_data,
-		    NULL);
+          "certificate", &der_data,
+          NULL);
       cert = g_array_sized_new (TRUE, TRUE, sizeof (guchar), der_data->len);
       g_array_append_vals (cert, der_data->data, der_data->len);
       g_byte_array_unref (der_data);
       g_ptr_array_add (certificates, cert);
 
       g_object_get (G_OBJECT (tlscert),
-                    "issuer", &tlscert,
-		    NULL);
+          "issuer", &tlscert,
+          NULL);
     }
 
   if (type != NULL)
@@ -335,7 +335,7 @@ wocky_tls_session_verify_peer (WockyTLSSession    *session,
 
 WockyTLSSession *
 wocky_tls_session_new (GIOStream  *stream,
-		       const char *peername)
+    const char *peername)
 {
   GTlsClientConnection *conn;
   GSocketConnectable *peer;
@@ -350,11 +350,9 @@ wocky_tls_session_new (GIOStream  *stream,
     return NULL;
 
   g_object_set (G_OBJECT (conn),
-
-		/* Accept everything; we'll check it afterwards */
-		"validation-flags", 0,
-
-		NULL);
+      /* Accept everything; we'll check it afterwards */
+      "validation-flags", 0,
+      NULL);
 
   return WOCKY_TLS_SESSION (conn);
 }

--- a/wocky/wocky-tls.h
+++ b/wocky/wocky-tls.h
@@ -75,10 +75,10 @@ typedef enum
   WOCKY_TLS_CERT_TYPE_OPENPGP, /* DANWFIXME: unused */
 } WockyTLSCertType;
 
-int wocky_tls_session_verify_peer (WockyTLSSession    *session,
-                                          GStrv               extra_identities,
-                                          WockyTLSVerificationLevel level,
-                                          WockyTLSCertStatus *status);
+int wocky_tls_session_verify_peer (WockyTLSSession *session,
+    GStrv extra_identities,
+    WockyTLSVerificationLevel level,
+    WockyTLSCertStatus *status);
 GPtrArray *wocky_tls_session_get_peers_certificate (WockyTLSSession *session,
     WockyTLSCertType *type);
 
@@ -90,7 +90,7 @@ void wocky_tls_session_add_ca (WockyTLSSession *session, const gchar *path);
 void wocky_tls_session_add_crl (WockyTLSSession *session, const gchar *path);
 
 WockyTLSSession *wocky_tls_session_new (GIOStream *stream,
-					const gchar *peername);
+    const gchar *peername);
 
 WockyTLSSession *wocky_tls_session_server_new (GIOStream   *stream,
                                                guint        dhbits,


### PR DESCRIPTION
I found it much more convenient to build, test and debug with meson, so here it is.

Till gabble is migrated to meson we'll need to drag both systems but that shouldn't be too much overhead.

Once autotools are deprecated we'll need to keep them only for certificate regeneration. I don't know how to do it efficiently in meson.