### PR TITLE
Multiple regression fixes

### DIFF
--- a/wocky/wocky-auth-handler.c
+++ b/wocky/wocky-auth-handler.c
@@ -5,34 +5,13 @@
 #include "wocky-auth-handler.h"
 #include "wocky-auth-registry.h"
 
-GType
-wocky_auth_handler_get_type (void)
+typedef WockyAuthHandlerIface WockyAuthHandlerInterface;
+
+G_DEFINE_INTERFACE (WockyAuthHandler, wocky_auth_handler, G_TYPE_OBJECT)
+
+static void
+wocky_auth_handler_default_init (WockyAuthHandlerInterface *iface)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
-
-  if (g_once_init_enter (&g_define_type_id__volatile))
-    {
-      const GTypeInfo info =
-      {
-        /* class_size */ sizeof (WockyAuthHandlerIface),
-        /* base_init */ NULL,
-        /* base_finalize */ NULL,
-        /* class_init */ NULL,
-        /* class_finalize */ NULL,
-        /* class_data */ NULL,
-        /* instance_size */ 0,
-        /* n_preallocs */ 0,
-        /* instance_init */ NULL,
-        /* value_table */ NULL
-      };
-      GType g_define_type_id = g_type_register_static (
-          G_TYPE_INTERFACE, "WockyAuthHandler", &info, 0);
-
-      g_type_interface_add_prerequisite (g_define_type_id, G_TYPE_OBJECT);
-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
-    }
-
-  return g_define_type_id__volatile;
 }
 
 /**

--- a/wocky/wocky-connector.c
+++ b/wocky/wocky-connector.c
@@ -373,6 +373,7 @@ abort_connect_error (WockyConnector *connector,
     }
 
   g_task_return_error (priv->task, g_error_copy (*error));
+  complete_operation (connector);
 }
 
 static void
@@ -395,6 +396,7 @@ abort_connect (WockyConnector *connector,
     }
 
   g_task_return_error (priv->task, g_error_copy (error));
+  complete_operation (connector);
 }
 
 static void

--- a/wocky/wocky-muc.c
+++ b/wocky/wocky-muc.c
@@ -1412,12 +1412,16 @@ get_message_sender (WockyMuc *muc,
 static GDateTime *
 extract_timestamp (WockyNode *msg)
 {
-  WockyNode *x = wocky_node_get_child_ns (msg, "x", WOCKY_XMPP_NS_DELAY);
+  WockyNode *x = wocky_node_get_child_ns (msg, "x", WOCKY_NS_JABBER_DELAY);
   GDateTime *stamp = NULL;
+
+  if (x == NULL)
+    x = wocky_node_get_child_ns (msg, "delay", WOCKY_XMPP_NS_DELAY);
 
   if (x != NULL)
     {
       const gchar *tm = wocky_node_get_attribute (x, "stamp");
+      GTimeZone *tz = g_time_zone_new_utc ();
 
       /* These timestamps do not contain a timezone, but are understood to be
        * in GMT. They're in the format yyyymmddThhmmss, so if we append 'Z'
@@ -1425,9 +1429,10 @@ extract_timestamp (WockyNode *msg)
        */
       if (tm != NULL)
         {
-          if ((stamp = g_date_time_new_from_iso8601 (tm, NULL)) == NULL)
+          if ((stamp = g_date_time_new_from_iso8601 (tm, tz)) == NULL)
             DEBUG ("Malformed date string '%s' for " WOCKY_XMPP_NS_DELAY, tm);
         }
+      g_time_zone_unref (tz);
     }
 
   return stamp;

--- a/wocky/wocky-namespaces.h
+++ b/wocky/wocky-namespaces.h
@@ -65,8 +65,11 @@
 #define WOCKY_XMPP_NS_EVENT \
   "jabber:x:event"
 
-#define WOCKY_XMPP_NS_DELAY \
+#define WOCKY_NS_JABBER_DELAY \
   "jabber:x:delay"
+
+#define WOCKY_XMPP_NS_DELAY \
+  "urn:xmpp:delay"
 
 #define WOCKY_XMPP_NS_STANZAS \
   "urn:ietf:params:xml:ns:xmpp-stanzas"

--- a/wocky/wocky-sasl-auth.c
+++ b/wocky/wocky-sasl-auth.c
@@ -289,9 +289,9 @@ auth_failed (WockySaslAuth *sasl, gint code, const gchar *format, ...)
 
   error = g_error_new_literal (WOCKY_AUTH_ERROR, code, message);
 
-  g_task_return_error (t, g_error_copy (error));
-
   wocky_auth_registry_failure (priv->auth_registry, error);
+
+  g_task_return_error (t, g_error_copy (error));
 
   g_object_unref (t);
 


### PR DESCRIPTION
Even though these regressions are not impacting local tests, gabble testing revealed multiple of them caused by recent modifications.
They are not fatal - wocky with gabble are still working ok in real life scenario but there is possibility of some unexpected behaviour in certain corner cases.
This set is required to complete gabble testing hence is a prerequisite to meson MR which introduces gabble CI pipeline.

Closes #20 